### PR TITLE
Add rotating Earth globe demo

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Rotating Earth with User Location</title>
+    <style>
+        body { margin: 0; overflow: hidden; }
+        #info { position: absolute; top: 0; width: 100%; text-align: center; padding: 0.5em; background: rgba(0,0,0,0.5); color: #fff; z-index: 1; }
+    </style>
+</head>
+<body>
+<div id="info">Allow location access to display your position.</div>
+<script src="https://unpkg.com/three@0.149.0/build/three.min.js"></script>
+<script src="https://unpkg.com/three@0.149.0/examples/js/controls/OrbitControls.js"></script>
+<script>
+    const scene = new THREE.Scene();
+    const camera = new THREE.PerspectiveCamera(60, window.innerWidth / window.innerHeight, 0.1, 1000);
+    const renderer = new THREE.WebGLRenderer({ antialias: true });
+    renderer.setSize(window.innerWidth, window.innerHeight);
+    document.body.appendChild(renderer.domElement);
+
+    const controls = new THREE.OrbitControls(camera, renderer.domElement);
+    camera.position.set(0, 0, 3);
+    controls.update();
+
+    const textureLoader = new THREE.TextureLoader();
+    const earthTexture = textureLoader.load('https://threejs.org/examples/textures/land_ocean_ice_cloud_2048.jpg');
+    const sphereGeometry = new THREE.SphereGeometry(1, 64, 64);
+    const sphereMaterial = new THREE.MeshBasicMaterial({ map: earthTexture });
+    const earth = new THREE.Mesh(sphereGeometry, sphereMaterial);
+    scene.add(earth);
+
+    const markerGeometry = new THREE.SphereGeometry(0.02, 32, 32);
+    const markerMaterial = new THREE.MeshBasicMaterial({ color: 0xff0000 });
+    const marker = new THREE.Mesh(markerGeometry, markerMaterial);
+    marker.visible = false;
+    scene.add(marker);
+
+    function latLongToVector3(lat, lon, radius) {
+        const phi = (90 - lat) * (Math.PI / 180);
+        const theta = (lon + 180) * (Math.PI / 180);
+        const x = -radius * Math.sin(phi) * Math.cos(theta);
+        const z = radius * Math.sin(phi) * Math.sin(theta);
+        const y = radius * Math.cos(phi);
+        return new THREE.Vector3(x, y, z);
+    }
+
+    function animate() {
+        requestAnimationFrame(animate);
+        earth.rotation.y += 0.0005;
+        controls.update();
+        renderer.render(scene, camera);
+    }
+    animate();
+
+    if (navigator.geolocation) {
+        navigator.geolocation.getCurrentPosition(pos => {
+            const lat = pos.coords.latitude;
+            const lon = pos.coords.longitude;
+            const position = latLongToVector3(lat, lon, 1.01);
+            marker.position.copy(position);
+            marker.visible = true;
+            document.getElementById('info').textContent = `Your Location: ${lat.toFixed(2)}, ${lon.toFixed(2)}`;
+        }, err => {
+            document.getElementById('info').textContent = 'Location access denied.';
+        });
+    } else {
+        document.getElementById('info').textContent = 'Geolocation not supported.';
+    }
+
+    window.addEventListener('resize', () => {
+        camera.aspect = window.innerWidth / window.innerHeight;
+        camera.updateProjectionMatrix();
+        renderer.setSize(window.innerWidth, window.innerHeight);
+    });
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create `index.html` that renders a Three.js Earth
- mark the user's geolocation on the globe if permission is granted

## Testing
- `No tests provided`


------
https://chatgpt.com/codex/tasks/task_e_68495fb2d474832488ba1779ebff5b41